### PR TITLE
Add PulseIndexLast for QGC logging

### DIFF
--- a/include/uavrt_interfaces/qgc_enum_class_definitions.hpp
+++ b/include/uavrt_interfaces/qgc_enum_class_definitions.hpp
@@ -158,6 +158,8 @@ enum class PulseIndex
 	PulseIndexQuaternionZ = 24,
 	// w element of the antenna orientation quaternion in free space. 
 	PulseIndexQuaternionW = 25
+	// Indicates last used index. This is used for logging the correct number of fields in QGC.
+	PulseIndexLast = 25
 };
 
 }  // namespace uavrt_interfaces


### PR DESCRIPTION
This will be used by QGC to log all the fields in the PulseIndex message. It should be updated as fields are added/removed. With this QGC can just loop from 0 to PulseIndexLast while writing out the log file. And whenever it changes it just takes a submodule update and recompile of QGC to bring it up to date.