### PR TITLE
Add channel_bin to TagInfo_t

### DIFF
--- a/include/uavrt_interfaces/TunnelProtocol.h
+++ b/include/uavrt_interfaces/TunnelProtocol.h
@@ -47,6 +47,8 @@ typedef struct {
 	uint32_t		k;
 	// Probability of a false alarm
 	double			false_alarm_probability;
+	// The 1-based channel which is input from the channelizer. 0 for unknown.
+	uint32_t		channelizer_bin;
 } TagInfo_t;
 
 typedef struct {


### PR DESCRIPTION
When the tuner is run by the ground station then the channel bin can be sent to the vehicle instead of being calc'ed on the vehicle